### PR TITLE
Changed pubnub.api.updateMembership to pubnub.api.updateMemberships

### DIFF
--- a/src/features/membership/commands/UpdateMembership.ts
+++ b/src/features/membership/commands/UpdateMembership.ts
@@ -75,7 +75,7 @@ export const updateMembership = <
     new Promise<void>((resolve, reject) => {
       dispatch(updatingMemberships<MembershipType, Meta>(request, meta));
 
-      pubnub.api.updateMembership(
+      pubnub.api.updateMemberships(
         {
           ...request,
         },


### PR DESCRIPTION
I guess PubNub API has renamed the pubnub.api.updateMembership to pubnub.api.updateMemberships.